### PR TITLE
docs: release process + script to automate

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,6 @@ npm run build
 
 [GitHub Actions](https://docs.github.com/en/actions) is used for our CI/CD workflows. See `.github/workflows` for details.
 
-## Releasing
-
-We use [semantic-release](https://semantic-release.gitbook.io/semantic-release/#highlights) to automatically create changelogs from commits, publish to npm, and create GitHub releases.
-
-[Read more](https://github.com/semantic-release/semantic-release/blob/6013a5633ecb71aac80f7b68b8e7250c5c58f7c0/docs/recipes/pre-releases.md) about publishing pre-releases.
-
-[Read more](https://github.com/semantic-release/semantic-release/blob/6013a5633ecb71aac80f7b68b8e7250c5c58f7c0/docs/usage/workflow-configuration.md#workflow-configuration) about expected behavior when pushing to the `main` and `beta` branches.
-
 ## License
 
 ```plaintext

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -1,0 +1,23 @@
+# Releasing
+
+We use [semantic-release](https://semantic-release.gitbook.io/semantic-release/#highlights) to automatically create changelogs from commits, publish to [npm](https://www.npmjs.com/package/@square/web-sdk), and create [GitHub releases](https://github.com/square/web-sdk/releases).
+
+Our `beta` git branch allows us to publish pre-releases as the `beta` tag on npm (i.e. `npm i @square/web-sdk@beta`). Pull Requests should target this branch so changes can be tried out before being promoted to the default distribution channel.
+
+Our `main` git branch is the default distribution channel which is published as the `latest` tag on npm (i.e. `npm i @square/web-sdk@latest`). Fixes can be made directly to this branch (preferably via Pull Request). Features, including breaking changes, should be developed and tested on the `beta` branch before being merged upstream to this `main` branch.
+
+Promoting features from `beta` to `main` is a manually process but a simple script:
+
+```sh
+./script/release.sh
+```
+
+That script will:
+
+1. get your local up to date
+1. merge `beta` into `main` using a merge commit strategy to help semantic-release
+1. push `main` to GitHub to trigger GitHub Actions which will run semantic-release
+
+[Read more](https://github.com/semantic-release/semantic-release/blob/6013a5633ecb71aac80f7b68b8e7250c5c58f7c0/docs/recipes/pre-releases.md) about publishing pre-releases.
+
+[Read more](https://github.com/semantic-release/semantic-release/blob/6013a5633ecb71aac80f7b68b8e7250c5c58f7c0/docs/usage/workflow-configuration.md#workflow-configuration) about expected behavior when pushing to the `main` and `beta` branches.

--- a/script/release.sh
+++ b/script/release.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+set -eux
+
+# get your local up to date
+git fetch origin
+# switch to default distribution branch
+git checkout main
+# create a merge commit from the pre-release branch
+git merge --no-ff --no-edit beta
+# push to github
+git push origin main
+# go back to beta for your next PR ;)
+git checkout beta


### PR DESCRIPTION
Releasing is easy! (And limited to @square/websdk for now)

When you want to promote the pre-release tag (`beta`) to the default distribution (`latest`), just run `./script/release.sh`

[Example release using this process](https://github.com/square/web-sdk/runs/2187157355?check_suite_focus=true). It may also be helpful to see [our network graph visualized](https://github.com/square/web-sdk/network).