### PR TITLE
fix: webpack 5 compatibility

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -115,7 +115,7 @@ export default {
   // resetModules: false,
 
   // A path to a custom resolver
-  // resolver: undefined,
+  resolver: 'jest-ts-webcompat-resolver',
 
   // Automatically restore mock state between every test
   // restoreMocks: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-square": "^17.0.0",
         "husky": "^6.0.0",
         "jest": "^26.6.3",
+        "jest-ts-webcompat-resolver": "^1.0.0",
         "lint-staged": "^11.0.0",
         "npm-run-all": "^4.1.5",
         "pinst": "^2.1.4",
@@ -9677,6 +9678,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-ts-webcompat-resolver": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jest-ts-webcompat-resolver/-/jest-ts-webcompat-resolver-1.0.0.tgz",
+      "integrity": "sha512-BFoaU7LeYqZNnTYEr6iMRf87xdCQntNc/Wk8YpzDBcuz+CIZ0JsTtzuMAMnKiEgTRTC1wRWLUo2RlVjVijBcHQ==",
+      "dev": true,
+      "peerDependencies": {
+        "jest-resolve": "*"
       }
     },
     "node_modules/jest-util": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint-plugin-square": "^17.0.0",
     "husky": "^6.0.0",
     "jest": "^26.6.3",
+    "jest-ts-webcompat-resolver": "^1.0.0",
     "lint-staged": "^11.0.0",
     "npm-run-all": "^4.1.5",
     "pinst": "^2.1.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export * from './payments';
+export * from './payments.js';
 
-// eslint-disable-next-line import/export -- not funny business, intentional types only
-export * from './types';
+// not funny business, intentional types only
+export * from './types.js';

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,4 +1,4 @@
-import type { Square } from './types';
+import type { Square } from './types.js';
 
 function findScript(src: string): HTMLScriptElement | null {
   return document.querySelector<HTMLScriptElement>(`script[src="${src}"]`);

--- a/src/payments.ts
+++ b/src/payments.ts
@@ -1,5 +1,5 @@
-import { loadSquare } from './load';
-import type { Payments } from './types';
+import { loadSquare } from './load.js';
+import type { Payments } from './types.js';
 
 const Version = 'v1';
 


### PR DESCRIPTION
**Please explain the changes you made here.**

Webpack 5 now requires the file extension when importing ([see docs](https://webpack.js.org/api/module-methods/#root)) so added the file extension to relevant imports. Create React App is now using Webpack 5 and adding compatibility would help resolve issues seen in the [`react-square-web-payments-sdk` library](https://github.com/weareseeed/react-square-web-payments-sdk/discussions/30) that Square featured in its latest [Square Developer Sandbox 101 video](https://youtu.be/GNo9y1CRcZ4).

I'm mainly a frontend/backend Swift developer so I'm a bit out of my element here but after I made these changes and confirmed it fixed a sample Create React App project, Jest started to throw errors that it couldn't find the modules I added the `.js` file extension to. I added `jest-ts-webcompat-resolver` to Jest's config which resolved the issue but completely open to better solution.

**Does this close any currently open issues?** No

- [x] [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed
