### PR TITLE
feat: harden application id validation

### DIFF
--- a/src/payments.test.ts
+++ b/src/payments.test.ts
@@ -17,7 +17,23 @@ describe('Payments', () => {
       expect(Payments).toHaveProperty('payments');
     });
 
-    it('throws if application id is invalid and has no override', async () => {
+    it('throws if application id is null and has no override', async () => {
+      // @ts-expect-error -- testing invalid type
+      await expect(Payments.payments(null)).rejects.toThrow(
+        "The Payment 'applicationId' option is not in the correct format.",
+      );
+      expect(mockLoadSquare).not.toHaveBeenCalled();
+    });
+
+    it('throws if application id is passed a non-string and has no override', async () => {
+      // @ts-expect-error -- testing invalid type
+      await expect(Payments.payments(999)).rejects.toThrow(
+        "The Payment 'applicationId' option is not in the correct format.",
+      );
+      expect(mockLoadSquare).not.toHaveBeenCalled();
+    });
+
+    it('throws if application id is passed an invalid string and has no override', async () => {
       await expect(Payments.payments('junk-app-id')).rejects.toThrow(
         "The Payment 'applicationId' option is not in the correct format.",
       );

--- a/src/payments.ts
+++ b/src/payments.ts
@@ -16,6 +16,10 @@ class InvalidApplicationIdError extends Error {
 function getSrcForApplicationId(applicationId: string): string {
   let src = '';
 
+  if (typeof applicationId !== 'string' || applicationId === null) {
+    throw new InvalidApplicationIdError();
+  }
+
   if (applicationId.startsWith('sq0idp-')) {
     src = 'https://web.squarecdn.com/';
   }


### PR DESCRIPTION
Simple change to confirm that payments is being passed a string applicationId.
