### PR TITLE
feat: Increase dependabot PR Limit from 5 to 15.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     target-branch: 'beta'
     commit-message:
       prefix: 'chore(deps): '
+    open-pull-requests-limit: 15


### PR DESCRIPTION
This allows dependabot to open up to 15 pull requests at a time, which will help us keep our dependencies up to date more efficiently.

_Does this close any currently open issues?_ No

- [x] [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed
