### PR TITLE
feat: Update Snowpack example to pass in verificationDetails

### DIFF
--- a/examples/snowpack/package-lock.json
+++ b/examples/snowpack/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "snowpack",
       "dependencies": {
-        "@square/web-sdk": "*"
+        "@square/web-sdk": "latest"
       },
       "devDependencies": {
         "snowpack": "^3.8.8"

--- a/examples/snowpack/pay.js
+++ b/examples/snowpack/pay.js
@@ -2,6 +2,23 @@ import * as Square from '@square/web-sdk';
 
 const applicationId = 'sandbox-sq0idb-lybe_WkfKNAbb3WklswmwA';
 const locationId = 'LKYXSPGPXK05M';
+const verificationDetails = {
+  amount: '1.00',
+  billingContact: {
+    givenName: 'John',
+    familyName: 'Doe',
+    email: 'john.doe@square.example',
+    phone: '3214563987',
+    addressLines: ['123 Main Street', 'Apartment 1'],
+    city: 'London',
+    state: 'LND',
+    countryCode: 'GB',
+  },
+  currencyCode: 'GBP',
+  intent: 'CHARGE',
+  customerInitiated: true,
+  sellerKeyedIn: false,
+};
 
 async function start() {
   const payments = await Square.payments(applicationId, locationId);
@@ -11,7 +28,7 @@ async function start() {
 
   document.querySelector('#pay').addEventListener('click', async () => {
     try {
-      const result = await card.tokenize();
+      const result = await card.tokenize(verificationDetails);
       console.log(result);
       // TODO: use result.token as source_id in /v2/payments API call
     } catch (ex) {


### PR DESCRIPTION
Update the Snowpack example to pass a `verificationDetails` object into `tokenize()` per the new payment flow.

_Does this close any currently open issues?_
No

- [x] [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed
