### PR TITLE
feat: use npm trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, beta]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -35,7 +38,6 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        id: test
         run: npm test
 
       - name: Collect coverage
@@ -44,9 +46,44 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  release:
+    if: ${{ github.event_name == 'push' }}
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24' # keep in sync w/ .nvmrc
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
       - name: Semantic Release
-        if: ${{ steps.test.conclusion == 'success' }}
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-registry=https://registry.npmjs.com/
+registry=https://registry.npmjs.org/
 access=public


### PR DESCRIPTION
## Why

npm write tokens now expire after at most 90 days and require manual rotation. npm Trusted Publishing replaces the long-lived publish credential with a short-lived GitHub Actions OIDC credential.

## What

- grant release-only OIDC and GitHub write permissions in a push-only job after tests pass
- remove `NPM_TOKEN` from semantic-release
- use npm’s canonical `registry.npmjs.org` URL so `@semantic-release/npm` detects trusted publishing


I already configured the npm Trusted Publisher for `@square/web-sdk`:

- Provider: GitHub Actions
- Organization: `square`
- Repository: `web-sdk`
- Workflow: `ci.yml`
- Action: `npm publish`

Without this npm-side configuration, releases from `main` or `beta` will fail.

After the first successful OIDC release, remove the GitHub `NPM_TOKEN` secret and revoke the old npm token.

## Verification

- `npm test`
- Prettier
- YAML parse
- `git diff --check`